### PR TITLE
Add VectorField and VectorFieldRenderer to enable multiple VFs in one View

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,8 @@ set(SOURCE_FILES
     src/SphereRenderer.cxx
     src/SurfaceRenderer.cxx
     src/Utilities.cxx
+    src/VectorField.cxx
+    src/VectorFieldRenderer.cxx
     src/VectorfieldIsosurface.cxx
     src/VectorSphereRenderer.cxx
     src/View.cxx
@@ -71,6 +73,8 @@ set(HEADER_FILES
     include/VFRendering/SphereRenderer.hxx
     include/VFRendering/SurfaceRenderer.hxx
     include/VFRendering/Utilities.hxx
+    include/VFRendering/VectorField.hxx
+    include/VFRendering/VectorFieldRenderer.hxx
     include/VFRendering/VectorSphereRenderer.hxx
     include/VFRendering/View.hxx
     include/shaders

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,11 @@ OBJS=\
 	build/GlyphRenderer.o\
 	build/View.o\
 	build/IsosurfaceRenderer.o\
+	build/VectorFieldRenderer.o\
 	build/VectorSphereRenderer.o\
 	build/SphereRenderer.o\
 	build/SurfaceRenderer.o\
+	build/VectorField.o\
 	build/VectorfieldIsosurface.o\
 	build/Utilities.o\
 	build/Options.o\
@@ -144,6 +146,11 @@ build/RendererBase.o: src/RendererBase.cxx \
   include/VFRendering/FPSCounter.hxx \
   include/VFRendering/Utilities.hxx \
   include/VFRendering/Geometry.hxx
+build/VectorFieldRenderer.o: src/VectorFieldRenderer.cxx \
+  include/VFRendering/VectorFieldRenderer.hxx \
+  include/VFRendering/VectorField.hxx \
+  include/VFRendering/View.hxx \
+  include/VFRendering/RendererBase.hxx
 build/SphereRenderer.o: src/SphereRenderer.cxx \
   include/VFRendering/SphereRenderer.hxx \
   include/VFRendering/RendererBase.hxx \
@@ -177,6 +184,11 @@ build/Utilities.o: src/Utilities.cxx \
   include/shaders/colormap.bluegreenred.glsl.hxx \
   include/shaders/colormap.bluewhitered.glsl.hxx
 build/VectorfieldIsosurface.o: src/VectorfieldIsosurface.cxx \
+  include/VFRendering/Geometry.hxx
+build/VectorField.o: src/VectorField.cxx \
+  include/VFRendering/Options.hxx \
+  include/VFRendering/FPSCounter.hxx \
+  include/VFRendering/Utilities.hxx \
   include/VFRendering/Geometry.hxx
 build/VectorSphereRenderer.o: src/VectorSphereRenderer.cxx \
   include/VFRendering/VectorSphereRenderer.hxx \

--- a/README.md
+++ b/README.md
@@ -55,18 +55,28 @@ This step highly depends on your use case. The **directions are stored as a `std
 
 As shown here, the directions should be in **C order** when using the `VFRendering::Geometry` static methods. If you do not know [glm](http://glm.g-truc.net/), think of a `glm::vec3` as a struct containing three floats x, y and z.
 
-### 4. Pass geometry and directions to a VFRendering::View
+### 4. Create a VFRendering::VectorField
+
+This class simply contains geometry and directions.
+
+``` c++
+    VFRendering::VectorField vf(geometry, directions);
+```
+
+To update the VectorField data, use `VectorField::update`.
+If the directions changed but the geometry is the same, you can use the `VectorField::updateVectors` method or `VectorField::updateGeometry` vice versa.
+
+### 5. Create a VFRendering::View and a Renderer
 
 The view object is what you will interact most with. It provides an interface to the various renderers and includes functions for handling mouse input.
 
-You can **create a new view** and then **pass the geometry and directions by calling the update method**:
+You can **create a new view** and then **initialize the renderer(s)** (as an example, we use the `VFRendering::ArrowRenderer`):
 
 ``` c++
     VFRendering::View view;
-    view.update(geometry, directions);
+    auto arrow_renderer_ptr = std::make_shared<VFRendering::ArrowRenderer>(view, vf);
+    view.renderers( {{ arrow_renderer_ptr, {0, 0, 1, 1} }} );
 ```
-
-If the directions changed but the geometry is the same, you can use the **updateVectors method**.
 
 ### 5. Draw the view in an existing OpenGL context
 
@@ -80,20 +90,21 @@ For a complete example, including an interactive camera, see demo.cxx.
 
 ## Renderers
 
-**libvfrendering** offers several types of renderers, which all inherit from VFRendering::RendererBase. Most important among these are:
+**libvfrendering** offers several types of renderers, which all inherit from `VFRendering::RendererBase`.
+The most relevant are the `VectorFieldRenderer`s:
 
-- VFRendering::ArrowRenderer, which renders the vectors as arrows
+- VFRendering::ArrowRenderer, which renders the vectors as colored arrows
+- VFRendering::SphereRenderer, which renders the vectors as colored spheres
 - VFRendering::SurfaceRenderer, which renders the surface of the geometry using a colormap
 - VFRendering::IsosurfaceRenderer, which renders an isosurface of the vectorfield using a colormap
 - VFRendering::VectorSphereRenderer, which renders the vectors as dots on a sphere, with the position of each dot representing the direction of the vector
 
-In addition to these, there also the following renderers:
+In addition to these, there also the following renderers which do not require a `VectorField`:
 - VFRendering::CombinedRenderer, which can be used to create a combination of several renderers, like an isosurface rendering with arrows
 - VFRendering::BoundingBoxRenderer, which is used for rendering bounding boxes around the geometry rendered by an VFRendering::ArrorRenderer, VFRendering::SurfaceRenderer or VFRendering::IsosurfaceRenderer
 - VFRendering::CoordinateSystemRenderer, which is used for rendering a coordinate system, with the axes colored by using the colormap
 
-To control what renderers are used, you can use `VFRendering::View::renderers`. As a convenience function it uses one main renderer (possibly with a bounding box), one alternative smaller renderer and a coordinate system.  
-Alternatively, you can pass it a `std::vector`s of `std::pair`s of renderers as VFRendering::RendererBase shared pointers and viewports as `glm::vec4`.
+To control what renderers are used, you can use `VFRendering::View::renderers`, where you can pass it a `std::vector`s of `std::pair`s of renderers as `std::shared_ptr<VFRendering::RendererBase>` (i.e. shared pointers) and viewports as `glm::vec4`.
 
 ## Options
 

--- a/demo.cxx
+++ b/demo.cxx
@@ -114,8 +114,9 @@ int main(void) {
         }
     }
     VFRendering::Geometry geometry = VFRendering::Geometry::cartesianGeometry({21, 21, 21}, {-20, -20, -20}, {20, 20, 20});
+    VFRendering::VectorField vf = VFRendering::VectorField();
+    vf.update(geometry, directions);
 
-    view.update(geometry, directions);
     VFRendering::Options options;
     options.set<VFRendering::View::Option::SYSTEM_CENTER>((geometry.min() + geometry.max()) * 0.5f);
     options.set<VFRendering::View::Option::COLORMAP_IMPLEMENTATION>(VFRendering::Utilities::getColormapImplementation(VFRendering::Utilities::Colormap::HSV));
@@ -124,20 +125,20 @@ int main(void) {
     options.set<VFRendering::View::Option::UP_VECTOR>({0, 1, 0});
     view.updateOptions(options);
 
-    auto isosurface_renderer_ptr = std::make_shared<VFRendering::IsosurfaceRenderer>(view);
+    auto isosurface_renderer_ptr = std::make_shared<VFRendering::IsosurfaceRenderer>(view, vf);
     isosurface_renderer_ptr->setOption<VFRendering::IsosurfaceRenderer::Option::VALUE_FUNCTION>([] (const glm::vec3& position, const glm::vec3& direction) -> VFRendering::IsosurfaceRenderer::isovalue_type {
         (void)position;
         return direction.z;
     });
     isosurface_renderer_ptr->setOption<VFRendering::IsosurfaceRenderer::Option::ISOVALUE>(0.0);
-    auto yzplane_renderer_ptr = std::make_shared<VFRendering::IsosurfaceRenderer>(view);
+    auto yzplane_renderer_ptr = std::make_shared<VFRendering::IsosurfaceRenderer>(view, vf);
     yzplane_renderer_ptr->setOption<VFRendering::IsosurfaceRenderer::Option::VALUE_FUNCTION>([] (const glm::vec3& position, const glm::vec3& direction) -> VFRendering::IsosurfaceRenderer::isovalue_type {
         (void)direction;
         return position.x;
     });
     yzplane_renderer_ptr->setOption<VFRendering::IsosurfaceRenderer::Option::ISOVALUE>(0.0);
-    auto arrow_renderer_ptr = std::make_shared<VFRendering::ArrowRenderer>(view);
-    auto sphere_renderer_ptr = std::make_shared<VFRendering::SphereRenderer>(view);
+    auto arrow_renderer_ptr = std::make_shared<VFRendering::ArrowRenderer>(view, vf);
+    auto sphere_renderer_ptr = std::make_shared<VFRendering::SphereRenderer>(view, vf);
     auto bounding_box_renderer_ptr = std::make_shared<VFRendering::BoundingBoxRenderer>(VFRendering::BoundingBoxRenderer::forCuboid(view, (geometry.min()+geometry.max())*0.5f, geometry.max()-geometry.min(), (geometry.max()-geometry.min())*0.2f, 0.5f));
     auto coordinate_system_renderer_ptr = std::make_shared<VFRendering::CoordinateSystemRenderer>(view);
     coordinate_system_renderer_ptr->setOption<VFRendering::CoordinateSystemRenderer::Option::AXIS_LENGTH>({0, 20, 20});

--- a/demo.cxx
+++ b/demo.cxx
@@ -114,8 +114,7 @@ int main(void) {
         }
     }
     VFRendering::Geometry geometry = VFRendering::Geometry::cartesianGeometry({21, 21, 21}, {-20, -20, -20}, {20, 20, 20});
-    VFRendering::VectorField vf = VFRendering::VectorField();
-    vf.update(geometry, directions);
+    VFRendering::VectorField vf = VFRendering::VectorField(geometry, directions);
 
     VFRendering::Options options;
     options.set<VFRendering::View::Option::SYSTEM_CENTER>((geometry.min() + geometry.max()) * 0.5f);

--- a/include/VFRendering/ArrowRenderer.hxx
+++ b/include/VFRendering/ArrowRenderer.hxx
@@ -14,7 +14,7 @@ public:
         LEVEL_OF_DETAIL
     };
 
-    ArrowRenderer(const View& view);
+    ArrowRenderer(const View& view, const VectorField& vf);
     virtual void optionsHaveChanged(const std::vector<int>& changed_options) override;
 };
 

--- a/include/VFRendering/GlyphRenderer.hxx
+++ b/include/VFRendering/GlyphRenderer.hxx
@@ -1,13 +1,13 @@
 #ifndef VFRENDERING_GLYPH_RENDERER_HXX
 #define VFRENDERING_GLYPH_RENDERER_HXX
 
-#include <VFRendering/RendererBase.hxx>
+#include <VFRendering/VectorFieldRenderer.hxx>
 
 namespace VFRendering {
-class GlyphRenderer : public RendererBase {
+class GlyphRenderer : public VectorFieldRenderer {
 public:
 
-    GlyphRenderer(const View& view);
+    GlyphRenderer(const View& view, const VectorField& vf);
     virtual ~GlyphRenderer();
     virtual void update(bool keep_geometry) override;
     virtual void draw(float aspect_ratio) override;

--- a/include/VFRendering/IsosurfaceRenderer.hxx
+++ b/include/VFRendering/IsosurfaceRenderer.hxx
@@ -3,10 +3,10 @@
 
 #include <functional>
 
-#include <VFRendering/RendererBase.hxx>
+#include <VFRendering/VectorFieldRenderer.hxx>
 
 namespace VFRendering {
-class IsosurfaceRenderer : public RendererBase {
+class IsosurfaceRenderer : public VectorFieldRenderer {
 public:
 
     typedef float isovalue_type;
@@ -19,7 +19,7 @@ public:
         FLIP_NORMALS
     };
 
-    IsosurfaceRenderer(const View& view);
+    IsosurfaceRenderer(const View& view, const VectorField& vf);
     virtual ~IsosurfaceRenderer();
     virtual void draw(float aspect_ratio) override;
     virtual void optionsHaveChanged(const std::vector<int>& changed_options) override;

--- a/include/VFRendering/RendererBase.hxx
+++ b/include/VFRendering/RendererBase.hxx
@@ -5,8 +5,8 @@
 
 #include <glm/glm.hpp>
 
-#include <VFRendering/Options.hxx>
 #include <VFRendering/View.hxx>
+#include <VFRendering/Options.hxx>
 
 namespace VFRendering {
 class RendererBase {
@@ -25,17 +25,11 @@ public:
 
 protected:
     const Options& options() const;
-    const std::vector<glm::vec3>& positions() const;
-    const std::vector<glm::vec3>& directions() const;
-    const std::vector<std::array<Geometry::index_type, 3>>& surfaceIndices() const;
-    const std::vector<std::array<Geometry::index_type, 4>>& volumeIndices() const;
     virtual void options(const Options& options);
 
 private:
     const View& m_view;
     Options m_options;
-    unsigned long m_geometry_update_id = 0;
-    unsigned long m_vectors_update_id = 0;
 };
 
 template<int index>

--- a/include/VFRendering/SphereRenderer.hxx
+++ b/include/VFRendering/SphereRenderer.hxx
@@ -11,7 +11,7 @@ public:
         LEVEL_OF_DETAIL
     };
 
-    SphereRenderer(const View& view);
+    SphereRenderer(const View& view, const VectorField& vf);
     virtual void optionsHaveChanged(const std::vector<int>& changed_options) override;
 };
 

--- a/include/VFRendering/SurfaceRenderer.hxx
+++ b/include/VFRendering/SurfaceRenderer.hxx
@@ -3,13 +3,13 @@
 
 #include <array>
 
-#include <VFRendering/RendererBase.hxx>
+#include <VFRendering/VectorFieldRenderer.hxx>
 
 namespace VFRendering {
 
-class SurfaceRenderer : public RendererBase {
+class SurfaceRenderer : public VectorFieldRenderer {
 public:
-    SurfaceRenderer(const View& view);
+    SurfaceRenderer(const View& view, const VectorField& vf);
     virtual ~SurfaceRenderer();
     virtual void draw(float aspect_ratio) override;
     virtual void optionsHaveChanged(const std::vector<int>& changed_options) override;

--- a/include/VFRendering/VectorField.hxx
+++ b/include/VFRendering/VectorField.hxx
@@ -1,0 +1,43 @@
+#ifndef VFRENDERING_VECTORFIELD_HXX
+#define VFRENDERING_VECTORFIELD_HXX
+
+#include <array>
+#include <memory>
+
+#include <glm/glm.hpp>
+
+#include <VFRendering/Options.hxx>
+#include <VFRendering/FPSCounter.hxx>
+#include <VFRendering/Utilities.hxx>
+#include <VFRendering/Geometry.hxx>
+
+namespace VFRendering {
+
+class VectorField {
+public:
+
+    VectorField();
+    virtual ~VectorField();
+
+    void update(const Geometry& geometry, const std::vector<glm::vec3>& vectors);
+    void updateGeometry(const Geometry& geometry);
+    void updateVectors(const std::vector<glm::vec3>& vectors);
+
+    const std::vector<glm::vec3>& positions() const;
+    const std::vector<glm::vec3>& directions() const;
+    const std::vector<std::array<Geometry::index_type, 3>>& surfaceIndices() const;
+    const std::vector<std::array<Geometry::index_type, 4>>& volumeIndices() const;
+
+    unsigned long geometryUpdateId() const;
+    unsigned long vectorsUpdateId() const;
+    
+private:
+    Geometry m_geometry;
+    std::vector<glm::vec3> m_vectors;
+    unsigned long m_geometry_update_id = 0;
+    unsigned long m_vectors_update_id = 0;
+};
+
+}
+
+#endif

--- a/include/VFRendering/VectorField.hxx
+++ b/include/VFRendering/VectorField.hxx
@@ -16,7 +16,7 @@ namespace VFRendering {
 class VectorField {
 public:
 
-    VectorField();
+    VectorField(const Geometry& geometry, const std::vector<glm::vec3>& vectors);
     virtual ~VectorField();
 
     void update(const Geometry& geometry, const std::vector<glm::vec3>& vectors);

--- a/include/VFRendering/VectorFieldRenderer.hxx
+++ b/include/VFRendering/VectorFieldRenderer.hxx
@@ -1,0 +1,35 @@
+#ifndef VFRENDERING_VECTORFIELD_RENDERER_HXX
+#define VFRENDERING_VECTORFIELD_RENDERER_HXX
+
+#include <vector>
+
+#include <glm/glm.hpp>
+
+#include <VFRendering/View.hxx>
+#include <VFRendering/VectorField.hxx>
+#include <VFRendering/RendererBase.hxx>
+
+namespace VFRendering {
+class VectorFieldRenderer  : public RendererBase {
+public:
+
+    VectorFieldRenderer(const View& view, const VectorField& vf);
+
+    virtual ~VectorFieldRenderer() {};
+    virtual void updateIfNecessary();
+
+protected:
+    const std::vector<glm::vec3>& positions() const;
+    const std::vector<glm::vec3>& directions() const;
+    const std::vector<std::array<Geometry::index_type, 3>>& surfaceIndices() const;
+    const std::vector<std::array<Geometry::index_type, 4>>& volumeIndices() const;
+
+private:
+    const VectorField& m_vf;
+    unsigned long m_geometry_update_id = 0;
+    unsigned long m_vectors_update_id = 0;
+};
+
+}
+
+#endif

--- a/include/VFRendering/VectorSphereRenderer.hxx
+++ b/include/VFRendering/VectorSphereRenderer.hxx
@@ -1,11 +1,11 @@
 #ifndef VFRENDERING_VECTOR_SPHERE_RENDERER_HXX
 #define VFRENDERING_VECTOR_SPHERE_RENDERER_HXX
 
-#include <VFRendering/RendererBase.hxx>
+#include <VFRendering/VectorFieldRenderer.hxx>
 
 namespace VFRendering {
 
-class VectorSphereRenderer : public RendererBase {
+class VectorSphereRenderer : public VectorFieldRenderer {
 public:
     enum Option {
         POINT_SIZE_RANGE = 400,
@@ -13,7 +13,7 @@ public:
         USE_SPHERE_FAKE_PERSPECTIVE
     };
 
-    VectorSphereRenderer(const View& view);
+    VectorSphereRenderer(const View& view, const VectorField& vf);
     virtual ~VectorSphereRenderer();
     virtual void draw(float aspect_ratio) override;
     virtual void optionsHaveChanged(const std::vector<int>& changed_options) override;

--- a/include/VFRendering/View.hxx
+++ b/include/VFRendering/View.hxx
@@ -48,18 +48,7 @@ public:
     void options(const Options& options);
     const Options& options() const;
 
-    void update(const Geometry& geometry, const std::vector<glm::vec3>& vectors);
-    void updateVectors(const std::vector<glm::vec3>& vectors);
-
-    const std::vector<glm::vec3>& positions() const;
-    const std::vector<glm::vec3>& directions() const;
-    const std::vector<std::array<Geometry::index_type, 3>>& surfaceIndices() const;
-    const std::vector<std::array<Geometry::index_type, 4>>& volumeIndices() const;
-
     void renderers(const std::vector<std::pair<std::shared_ptr<RendererBase>, std::array<float, 4>>>& renderers);
-
-    unsigned long geometryUpdateId() const;
-    unsigned long vectorsUpdateId() const;
     
 private:
     void setCamera(glm::vec3 camera_position, glm::vec3 center_position, glm::vec3 up_vector);
@@ -67,14 +56,10 @@ private:
     void initialize();
 
     bool m_is_initialized = false;
-    Geometry m_geometry;
-    std::vector<glm::vec3> m_vectors;
     std::vector<std::pair<std::shared_ptr<RendererBase>, std::array<float, 4>>> m_renderers;
     Utilities::FPSCounter m_fps_counter;
     glm::vec2 m_framebuffer_size;
     bool m_is_centered = false;
-    unsigned long m_geometry_update_id = 0;
-    unsigned long m_vectors_update_id = 0;
 
     Options m_options;
 };

--- a/qt/VFRenderingWidget.cxx
+++ b/qt/VFRenderingWidget.cxx
@@ -6,7 +6,7 @@
 #include <QWheelEvent>
 
 VFRenderingWidget::VFRenderingWidget(QWidget *parent) : QOpenGLWidget(parent) {
-  m_vf = VFRendering::VectorField();
+  m_vf = VFRendering::VectorField({}, {});
 }
 
 VFRenderingWidget::~VFRenderingWidget() {}

--- a/qt/VFRenderingWidget.cxx
+++ b/qt/VFRenderingWidget.cxx
@@ -1,14 +1,19 @@
 #include "VFRenderingWidget.hxx"
 
+#include <VFRendering/ArrowRenderer.hxx>
+
 #include <vector>
 #include <QWheelEvent>
 
-VFRenderingWidget::VFRenderingWidget(QWidget *parent) : QOpenGLWidget(parent) {}
+VFRenderingWidget::VFRenderingWidget(QWidget *parent) : QOpenGLWidget(parent) {
+  m_vf = VFRendering::VectorField();
+}
 
 VFRenderingWidget::~VFRenderingWidget() {}
 
 void VFRenderingWidget::initializeGL() {
   setMouseTracking(true);
+  m_view.renderers({{ std::make_shared<VFRendering::ArrowRenderer>(m_view, m_vf), {{0, 0, 1, 1}} }});
 }
 
 void VFRenderingWidget::resizeGL(int width, int height) {
@@ -16,12 +21,12 @@ void VFRenderingWidget::resizeGL(int width, int height) {
 }
 
 void VFRenderingWidget::update(const VFRendering::Geometry& geometry, const std::vector<glm::vec3>& vectors) {
-  m_view.update(geometry, vectors);
+  m_vf.update(geometry, vectors);
 }
 
 
 void VFRenderingWidget::updateVectors(const std::vector<glm::vec3>& vectors) {
-  m_view.updateVectors(vectors);
+  m_vf.updateVectors(vectors);
 }
 
 void VFRenderingWidget::updateOptions(const VFRendering::Options& options) {

--- a/qt/VFRenderingWidget.hxx
+++ b/qt/VFRenderingWidget.hxx
@@ -7,10 +7,12 @@
 
 #include <glm/vec3.hpp>
 #include <VFRendering/View.hxx>
+#include <VFRendering/VectorField.hxx>
 #include <VFRendering/Geometry.hxx>
 
 namespace VFRendering {
   class View;
+  class VectorField;
 }
 
 class VFRenderingWidget : public QOpenGLWidget {
@@ -34,6 +36,7 @@ protected:
 
 private:
     VFRendering::View m_view;
+    VFRendering::VectorField m_vf;
     QPoint m_previous_mouse_position;
 };
 

--- a/src/ArrowRenderer.cxx
+++ b/src/ArrowRenderer.cxx
@@ -4,9 +4,8 @@
 
 namespace VFRendering {
 static void setArrowMeshOptions(GlyphRenderer& renderer, const Options& options);
-
-ArrowRenderer::ArrowRenderer(const View& view) : GlyphRenderer(view) {
-  setArrowMeshOptions(*this, options());
+ArrowRenderer::ArrowRenderer(const View& view, const VectorField& vf) : GlyphRenderer(view, vf) {
+    setArrowMeshOptions(*this, this->options());
 }
 
 void ArrowRenderer::optionsHaveChanged(const std::vector<int>& changed_options) {

--- a/src/GlyphRenderer.cxx
+++ b/src/GlyphRenderer.cxx
@@ -10,7 +10,7 @@
 #include "shaders/glyphs.frag.glsl.hxx"
 
 namespace VFRendering {
-GlyphRenderer::GlyphRenderer(const View& view) : RendererBase(view) {}
+GlyphRenderer::GlyphRenderer(const View& view, const VectorField& vf) : VectorFieldRenderer(view, vf) {}
 
 void GlyphRenderer::initialize() {
     if (m_is_initialized) {

--- a/src/IsosurfaceRenderer.cxx
+++ b/src/IsosurfaceRenderer.cxx
@@ -12,7 +12,7 @@
 #include "shaders/isosurface.frag.glsl.hxx"
 
 namespace VFRendering {
-IsosurfaceRenderer::IsosurfaceRenderer(const View& view) : RendererBase(view), m_value_function_changed(true), m_isovalue_changed(true) {}
+IsosurfaceRenderer::IsosurfaceRenderer(const View& view, const VectorField& vf) : VectorFieldRenderer(view, vf), m_value_function_changed(true), m_isovalue_changed(true) {}
 
 void IsosurfaceRenderer::initialize() {
     if (m_is_initialized) {

--- a/src/RendererBase.cxx
+++ b/src/RendererBase.cxx
@@ -1,26 +1,10 @@
 #include "VFRendering/RendererBase.hxx"
 
 namespace VFRendering {
-RendererBase::RendererBase(const View& view) : m_view(view), m_options(view.options()) {}
+RendererBase::RendererBase(const View& view) : m_view(view), m_options(m_view.options()) {}
 
 const Options& RendererBase::options() const {
     return m_options;
-}
-
-const std::vector<glm::vec3>& RendererBase::positions() const {
-    return m_view.positions();
-}
-
-const std::vector<glm::vec3>& RendererBase::directions() const {
-    return m_view.directions();
-}
-
-const std::vector<std::array<Geometry::index_type, 3>>& RendererBase::surfaceIndices() const {
-    return m_view.surfaceIndices();
-}
-
-const std::vector<std::array<Geometry::index_type, 4>>& RendererBase::volumeIndices() const {
-    return m_view.volumeIndices();
 }
 
 void RendererBase::options(const Options& options) {
@@ -40,15 +24,6 @@ void RendererBase::updateOptions(const Options& options) {
     optionsHaveChanged(changed_options);
 }
 
-void RendererBase::updateIfNecessary() {
-    if (m_geometry_update_id != m_view.geometryUpdateId()) {
-        update(false);
-        m_geometry_update_id = m_view.geometryUpdateId();
-        m_vectors_update_id = m_view.vectorsUpdateId();
-    } else if (m_vectors_update_id != m_view.vectorsUpdateId()) {
-        update(true);
-        m_vectors_update_id = m_view.vectorsUpdateId();
-    }
-}
+void RendererBase::updateIfNecessary() { }
 
 }

--- a/src/SphereRenderer.cxx
+++ b/src/SphereRenderer.cxx
@@ -6,8 +6,8 @@
 namespace VFRendering {
 static void setSphereMeshOptions(GlyphRenderer& renderer, const Options& options);
 
-SphereRenderer::SphereRenderer(const View& view) : GlyphRenderer(view) {
-  setSphereMeshOptions(*this, options());
+SphereRenderer::SphereRenderer(const View& view, const VectorField& vf) : GlyphRenderer(view, vf) {
+  setSphereMeshOptions(*this, this->options());
 }
 
 void SphereRenderer::optionsHaveChanged(const std::vector<int>& changed_options) {

--- a/src/SurfaceRenderer.cxx
+++ b/src/SurfaceRenderer.cxx
@@ -10,7 +10,7 @@
 #include "shaders/surface.frag.glsl.hxx"
 
 namespace VFRendering {
-SurfaceRenderer::SurfaceRenderer(const View& view) : RendererBase(view) {}
+SurfaceRenderer::SurfaceRenderer(const View& view, const VectorField& vf) : VectorFieldRenderer(view, vf) {}
 
 void SurfaceRenderer::initialize() {
     if (m_is_initialized) {

--- a/src/VectorField.cxx
+++ b/src/VectorField.cxx
@@ -3,8 +3,9 @@
 #include <iostream>
 
 namespace VFRendering {
-VectorField::VectorField() {
-    
+VectorField::VectorField(const Geometry& geometry, const std::vector<glm::vec3>& vectors) : m_geometry(geometry), m_vectors(vectors) {
+    m_vectors_update_id++;
+    m_geometry_update_id++;
 }
 
 VectorField::~VectorField() {}

--- a/src/VectorField.cxx
+++ b/src/VectorField.cxx
@@ -1,0 +1,53 @@
+#include "VFRendering/VectorField.hxx"
+
+#include <iostream>
+
+namespace VFRendering {
+VectorField::VectorField() {
+    
+}
+
+VectorField::~VectorField() {}
+
+void VectorField::update(const Geometry& geometry, const std::vector<glm::vec3>& vectors) {
+    m_geometry = geometry;
+    m_vectors = vectors;
+    m_vectors_update_id++;
+    m_geometry_update_id++;
+}
+
+void VectorField::updateGeometry(const Geometry& geometry) {
+    m_geometry = geometry;
+    m_geometry_update_id++;
+}
+
+void VectorField::updateVectors(const std::vector<glm::vec3>& vectors) {
+    m_vectors = vectors;
+    m_vectors_update_id++;
+}
+
+
+unsigned long VectorField::geometryUpdateId() const {
+    return m_geometry_update_id;
+}
+
+unsigned long VectorField::vectorsUpdateId() const {
+    return m_vectors_update_id;
+}
+
+const std::vector<glm::vec3>& VectorField::positions() const {
+    return m_geometry.positions();
+}
+
+const std::vector<glm::vec3>& VectorField::directions() const {
+    return m_vectors;
+}
+
+const std::vector<std::array<Geometry::index_type, 3>>& VectorField::surfaceIndices() const {
+    return m_geometry.surfaceIndices();
+}
+
+const std::vector<std::array<Geometry::index_type, 4>>& VectorField::volumeIndices() const {
+    return m_geometry.volumeIndices();
+}
+}

--- a/src/VectorFieldRenderer.cxx
+++ b/src/VectorFieldRenderer.cxx
@@ -1,0 +1,33 @@
+#include "VFRendering/VectorFieldRenderer.hxx"
+
+namespace VFRendering {
+VectorFieldRenderer::VectorFieldRenderer(const View& view, const VectorField& vf)  : RendererBase(view), m_vf(vf) {}
+
+const std::vector<glm::vec3>& VectorFieldRenderer::positions() const {
+    return m_vf.positions();
+}
+
+const std::vector<glm::vec3>& VectorFieldRenderer::directions() const {
+    return m_vf.directions();
+}
+
+const std::vector<std::array<Geometry::index_type, 3>>& VectorFieldRenderer::surfaceIndices() const {
+    return m_vf.surfaceIndices();
+}
+
+const std::vector<std::array<Geometry::index_type, 4>>& VectorFieldRenderer::volumeIndices() const {
+    return m_vf.volumeIndices();
+}
+
+void VectorFieldRenderer::updateIfNecessary() {
+    if (m_geometry_update_id != m_vf.geometryUpdateId()) {
+        update(false);
+        m_geometry_update_id = m_vf.geometryUpdateId();
+        m_vectors_update_id = m_vf.vectorsUpdateId();
+    } else if (m_vectors_update_id != m_vf.vectorsUpdateId()) {
+        update(true);
+        m_vectors_update_id = m_vf.vectorsUpdateId();
+    }
+}
+
+}

--- a/src/VectorSphereRenderer.cxx
+++ b/src/VectorSphereRenderer.cxx
@@ -13,7 +13,7 @@
 #include "shaders/sphere_background.frag.glsl.hxx"
 
 namespace VFRendering {
-VectorSphereRenderer::VectorSphereRenderer(const View& view) : RendererBase(view) {}
+VectorSphereRenderer::VectorSphereRenderer(const View& view, const VectorField& vf) : VectorFieldRenderer(view, vf) {}
 
 void VectorSphereRenderer::initialize() {
     if (m_is_initialized) {

--- a/src/View.cxx
+++ b/src/View.cxx
@@ -15,9 +15,7 @@
 #include "VFRendering/CoordinateSystemRenderer.hxx"
 
 namespace VFRendering {
-View::View() {
-    renderers({{std::make_shared<ArrowRenderer>(*this), {{0, 0, 1, 1}}}});
-}
+View::View() { }
 
 void View::initialize() {
     if (m_is_initialized) {
@@ -36,18 +34,6 @@ void View::initialize() {
 }
 
 View::~View() {}
-
-void View::update(const Geometry& geometry, const std::vector<glm::vec3>& vectors) {
-    m_geometry = geometry;
-    m_vectors = vectors;
-    m_vectors_update_id++;
-    m_geometry_update_id++;
-}
-
-void View::updateVectors(const std::vector<glm::vec3>& vectors) {
-    m_vectors = vectors;
-    m_vectors_update_id++;
-}
 
 void View::draw() {
     initialize();
@@ -194,29 +180,5 @@ void View::optionsHaveChanged(const std::vector<int>& changed_options) {
         center_position = options().get<Option::SYSTEM_CENTER>();
         setCamera(camera_position, center_position, up_vector);
     }
-}
-
-unsigned long View::geometryUpdateId() const {
-    return m_geometry_update_id;
-}
-
-unsigned long View::vectorsUpdateId() const {
-    return m_vectors_update_id;
-}
-
-const std::vector<glm::vec3>& View::positions() const {
-    return m_geometry.positions();
-}
-
-const std::vector<glm::vec3>& View::directions() const {
-    return m_vectors;
-}
-
-const std::vector<std::array<Geometry::index_type, 3>>& View::surfaceIndices() const {
-    return m_geometry.surfaceIndices();
-}
-
-const std::vector<std::array<Geometry::index_type, 4>>& View::volumeIndices() const {
-    return m_geometry.volumeIndices();
 }
 }


### PR DESCRIPTION
### **This PR is so far only meant for discussion of this refactoring I tried**
*The demo has not been updated yet.*


- The `VectorField` class contains all vector-field-specific data previously contained in `View`. It also provides functions to update the geometry, directions, or both.
- The `VectorFieldRenderer` is an abstraction to distinguish from `Renderer`s which do not contain a VF, such as `CombinedRenderer` or `CoordinateSystemRenderer`.
- Also added the Bounded camera rotation type


**Questions:**
- *does this clutter the class structure too much?*
- *does this complicate the simple use cases too much?*


**My Opinions:**
- *it is more intuitive to have multiple vector-fields than to **need** multiple `View`s*
- *it makes sense to use multiple `View`s when e.g. different camera settings for the different objects are wanted for some reason*
- *this gives a clear hierachy of `Renderer`s, where only some actually visualise a vector-field*
- *this way it is easy to create complex combinations of different vector-fields without needing wrapper functions to handle synchronization of `Option`s*